### PR TITLE
Added theme switcher

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,50 +1,53 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <script
-      src="https://kit.fontawesome.com/1eb44e0a35.js"
-      crossorigin="anonymous"
-    ></script>
-    <link rel="stylesheet" href="style.css" />
-    <link
-      rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@500&display=swap"
-    />
-    <script src="script.js" defer></script>
-    <title>Terminal</title>
-    <link rel="icon" type="image/jpg" href="favicon.ico">
-  </head>
-  <body>
-    <div class="container">
-      <div class="menu">
-        <div class="buttons-flex">
-          <div class="button green"></div>
-          <div class="button yellow"></div>
-          <div class="button red"></div>
-        </div>
-        <div class="title">
-          <a href="http://github.com/techspiritss">
-            <h1>
-              <i class="fab fa-globe"></i>
-              TechSpiritSS
-            </h1>
-          </a>
-        </div>
+
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <script src="https://kit.fontawesome.com/1eb44e0a35.js" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="style.css" />
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@500&display=swap" />
+  <link rel="stylesheet" id="switcher-id" href="">
+  <script src="script.js" defer></script>
+  <title>Terminal</title>
+  <link rel="icon" type="image/jpg" href="favicon.ico">
+</head>
+
+<body>
+  <div class="container">
+    <div class="menu">
+      <div class="buttons-flex">
+        <div class="button green"></div>
+        <div class="button yellow"></div>
+        <div class="button red"></div>
       </div>
-      <div id="app"></div>
       <div class="title">
-        <p class="bottom-bar">
-          &copy;
-          <script>
-            document.write(new Date().getFullYear());
-          </script>
-          <a href="http://github.com/techspiritss" class="bottom-name">
-            Sidharth Sethi</a
-          >
-        </p>
+        <a href="http://github.com/techspiritss">
+          <h1>
+            <i class="fab fa-globe"></i>
+            TechSpiritSS
+          </h1>
+        </a>
+      </div>
+      <div class="theme-switches">
+        <div data-theme="default" class="switch" id="switch5"></div>
+        <div data-theme="nature" class="switch" id="switch1"></div>
+        <div data-theme="metalic" class="switch" id="switch2"></div>
+        <div data-theme="matrix" class="switch" id="switch3"></div>
+        <div data-theme="sky" class="switch" id="switch4"></div>
       </div>
     </div>
-  </body>
+    <div id="app"></div>
+    <div class="title">
+      <p class="bottom-bar">
+        &copy;
+        <script>
+          document.write(new Date().getFullYear());
+        </script>
+        <a href="http://github.com/techspiritss" class="bottom-name">
+          Sidharth Sethi</a>
+      </p>
+    </div>
+  </div>
+</body>
 </html>

--- a/index.html
+++ b/index.html
@@ -32,7 +32,15 @@
             </h1>
           </a>
         </div>
+        <div class="theme-switches">
+          <div data-theme="default" class="switch" id="switch5"></div>
+          <div data-theme="nature" class="switch" id="switch1"></div>
+          <div data-theme="metalic" class="switch" id="switch2"></div>
+          <div data-theme="matrix" class="switch" id="switch3"></div>
+          <div data-theme="sky" class="switch" id="switch4"></div>
+        </div>
       </div>
+      <div id="app"></div>
       <div class="title">
         <div class="bottom-bar">
           &copy;
@@ -44,25 +52,6 @@
           >
           </div>
       </div>
-      <div class="theme-switches">
-        <div data-theme="default" class="switch" id="switch5"></div>
-        <div data-theme="nature" class="switch" id="switch1"></div>
-        <div data-theme="metalic" class="switch" id="switch2"></div>
-        <div data-theme="matrix" class="switch" id="switch3"></div>
-        <div data-theme="sky" class="switch" id="switch4"></div>
-      </div>
     </div>
-    <div id="app"></div>
-    <div class="title">
-      <p class="bottom-bar">
-        &copy;
-        <script>
-          document.write(new Date().getFullYear());
-        </script>
-        <a href="http://github.com/techspiritss" class="bottom-name">
-          Sidharth Sethi</a>
-      </p>
-    </div>
-  </div>
-</body>
+  </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
     <script src="script.js" defer></script>
     <title>Terminal</title>
     <link rel="icon" type="image/jpg" href="favicon.ico">
+    <link rel="stylesheet" id="switcher-id" href="">
   </head>
   <body id="bodyContainer">
     <div id="screenContainer" class="container">

--- a/script.js
+++ b/script.js
@@ -199,3 +199,40 @@ function createCode(code, text) {
 }
 
 openTerminal();
+
+
+// Themes Switcher
+
+let switches = document.getElementsByClassName('switch');
+
+let style = localStorage.getItem('style');
+
+if (style == null) {
+  setTheme('default');
+} else {
+  setTheme(style);
+}
+
+for (let i of switches) {
+  i.addEventListener('click', function () {
+    let theme = this.dataset.theme;
+    setTheme(theme);
+  });
+}
+
+function setTheme(theme) {
+  if (theme == 'nature') {
+    document.getElementById('switcher-id').href = './themes/nature.css';
+  } else if (theme == 'sky') {
+    document.getElementById('switcher-id').href = './themes/sky.css';
+  } else if (theme == 'matrix') {
+    document.getElementById('switcher-id').href = './themes/matrix.css';
+  } else if (theme == 'metalic') {
+    document.getElementById('switcher-id').href = './themes/metalic.css';
+  } else if (theme == 'default') {
+    document.getElementById('switcher-id').href = './themes/default.css';
+  }
+  
+  localStorage.setItem('style', theme);
+}
+setTheme('default');

--- a/style.css
+++ b/style.css
@@ -2,7 +2,55 @@
 
 :root {
   --font-size: 1.3rem;
+  --metalic: #6e94ad;
+  --sky: #f5ebe1;
+  --matrix: lime;
+  --nature: #cda76e;
+  --default: #fc766aff;
 }
+
+
+.theme-switches {
+  display: flex;
+  flex-grow: 1;
+  flex-basis: 0;
+  justify-content: end;
+}
+
+.switch {
+  border: 2px solid black;
+  border-radius: 50px;
+  height: 30px;
+  width: 30px;
+  margin: 10px;
+  cursor: pointer;
+}
+
+.switch:hover {
+  transform: scale(1.2);
+  transition: 0.3s ease-in-out;
+}
+
+#switch1 {
+  background-color: var(--nature);
+}
+
+#switch2 {
+  background-color: var(--metalic);
+}
+
+#switch3 {
+  background-color: var(--matrix);
+}
+
+#switch4 {
+  background-color: var(--sky);
+}
+
+#switch5 {
+  background-color: var(--default);
+}
+
 
 * {
   margin: 0;
@@ -68,6 +116,7 @@ body {
   display: flex;
   align-items: center;
   text-align: center;
+  justify-content: space-between;
   width: 100%;
   height: 45px;
   background-color: #faa094ff;
@@ -85,9 +134,10 @@ body {
 }
 
 .buttons-flex {
-  position: absolute;
   display: flex;
   flex-direction: row;
+  flex-grow: 1;
+  flex-basis: 0;
 }
 
 .red {
@@ -117,6 +167,9 @@ div.title {
     position: unset;
     display: flex;
     flex-direction: row;
+  }
+  .theme-switches {
+    display: none;
   }
 }
 

--- a/themes/default.css
+++ b/themes/default.css
@@ -1,0 +1,75 @@
+.container {
+  border: 1px solid rgb(212, 12, 12);
+}
+
+.menu {
+  background-color: #faa094ff;
+}
+
+.menu h1 {
+  color: #000000;
+}
+
+#app {
+  background-color: #ffdde2ff;
+}
+
+p {
+  color: #000000;
+}
+
+.bottom-bar {
+  background-color: #fc766aff;
+}
+
+.bottom-name {
+  color: #000000;
+}
+
+h2 {
+  color: #008c76ff;
+}
+
+p.code {
+  color: #faea48;
+}
+
+span.text {
+  color: #00ffc6;
+}
+
+p.path {
+  color: #240a8e;
+}
+
+p.path span {
+  color: #3ec70b;
+}
+
+p.path span + span {
+  color: #3b44f6;
+}
+
+.success {
+  color: #008c76ff;
+}
+
+.error {
+  color: #c50000;
+}
+
+p.response {
+  color: #37e2d5;
+}
+
+input {
+  color: #ff8d29;
+}
+
+.icone {
+  color: #008c76ff;
+}
+
+.icone.error {
+  color: #ff1700;
+}

--- a/themes/matrix.css
+++ b/themes/matrix.css
@@ -1,0 +1,83 @@
+@import url('https://fonts.googleapis.com/css2?family=VT323&display=swap');
+
+:root {
+    --back-color: #1b1b1b;
+    --primary-color: #702459;
+    --header-back: #874f5e;
+    --header-text: #eee;
+  }
+  
+  body {
+    background-color: var(--back-color);
+    color: var(--primary-color);
+  }
+  
+  header {
+    background-color: var(--header-back);
+    color: var(--header-text);
+  }
+  
+  .box img {
+    border: 2px solid var(--primary-color);
+  }
+
+  .menu { /* top bar */
+    background-color: black;
+}
+
+.bottom-bar {
+    background-color: black;
+}
+
+.bottom-name, .menu h1, .bottom-bar {
+    color: white;
+}
+
+p {
+    color: #96905f;
+}
+
+h2 {
+    color: lime;
+}
+
+
+#app { /* main content */
+    background-color: black;
+}
+
+p.path { /* username */
+    color: lime !important;
+}
+
+#app p { /* main text */
+    color: lime;
+}
+
+p.path span { /* sudo */
+    color: lime;
+}
+
+p.path span + span { /* directory */
+    color: lime;
+}
+
+.icone {
+    color: lime;
+}
+
+input {
+    color: lime;
+}
+
+.error {
+    background-color: #;
+}
+
+.container {
+    border: .5px solid rgb(47, 47, 47);
+}
+
+* {
+    font-family: "VT323", monospace;
+}

--- a/themes/metalic.css
+++ b/themes/metalic.css
@@ -1,0 +1,76 @@
+:root {
+    --back-color: #1d272a;
+    --primary-color: #f9ffee;
+    --header-back: #1a1d24;
+    --header-text: #eee;
+}
+
+body {
+    background-color: var(--back-color);
+    color: var(--primary-color);
+}
+
+header {
+    background-color: var(--header-back);
+    color: var(--header-text);
+}
+
+.box img {
+    border: 2px solid var(--primary-color);
+}
+
+.menu { /* top bar */
+    background-color: #3f545a;
+}
+
+.bottom-bar {
+    background-color: #0e1314;
+}
+
+.menu h1 {
+    color: #f9ffee;
+}
+
+.bottom-name, .bottom-bar {
+    color: #727272;
+}
+
+p {
+    color: #f9ffee;
+}
+
+#app { /* main content */
+    background-color: #1d272a;
+}
+
+p.path { /* username */
+    color: #7a9f81 !important;
+}
+
+#app p { /* main text */
+    color: #6e94ad;
+}
+
+p.path span {
+    color: #ff8800;
+}
+
+p.path span + span {
+    color: #937aba;
+}
+
+.icone {
+    color: #6e94ad;
+}
+
+input {
+    background-color: #;
+}
+
+.error {
+    background-color: #;
+}
+
+.container {
+    border: 1px solid #000000;
+}

--- a/themes/nature.css
+++ b/themes/nature.css
@@ -1,0 +1,77 @@
+:root {
+    --back-color: #a18d70;
+    --primary-color: #000000;
+    --header-back: #5d5d5d;
+    --header-text: #eee;
+  }
+  
+  body {
+    background-color: var(--back-color);
+    color: var(--primary-color);
+  }
+  
+  header {
+    background-color: var(--header-back);
+    color: var(--header-text);
+  }
+  
+  .box img {
+    border: 2px solid var(--primary-color);
+  }
+
+  .menu { /* top bar */
+    background-color: #4b4343;
+}
+
+.bottom-bar {
+    background-color: #1e1a1a;
+}
+
+.bottom-name, .menu h1, .bottom-bar {
+    color: #f9ffee;
+}
+
+p {
+    color: #96905f;
+}
+
+h2, a {
+    color: #71a46c;
+}
+
+
+#app { /* main content */
+    background-color: #292424;
+}
+
+p.path { /* username */
+    color: #c27d7b !important;
+}
+
+#app p { /* main text */
+    color: #96905f;
+}
+
+p.path span { /* sudo */
+    color: #e81050;
+}
+
+p.path span + span { /* directory */
+    color: #b680b1;
+}
+
+.icone {
+    color: #96905f;
+}
+
+input {
+    color: #8b8fc6;
+}
+
+.error {
+    background-color: #;
+}
+
+.container {
+    border: 1px solid #000000;
+}

--- a/themes/sky.css
+++ b/themes/sky.css
@@ -1,0 +1,81 @@
+:root {
+    --back-color: #c3dafe;
+    --primary-color: #3c366b;
+    --header-back: #5f718d;
+    --header-text: #eee;
+  }
+  
+  body {
+    background-color: var(--back-color);
+    color: var(--primary-color);
+  }
+  
+  header {
+    background-color: var(--header-back);
+    color: var(--header-text);
+  }
+  
+  .box img {
+    border: 2px solid var(--primary-color);
+  }
+
+  .menu { /* top bar */
+    background-color: #efdfcf;
+}
+
+.bottom-bar {
+    background-color: #efdfcf;
+}
+
+.bottom-name, .menu h1, .bottom-bar {
+    color: #585858;
+}
+
+p {
+    color: #96905f;
+}
+
+h2 {
+    color: #81b6bc;
+}
+
+
+#app { /* main content */
+    background-color: #f5ebe1;
+}
+
+p.path { /* username */
+    color: #8c4a79 !important;
+}
+
+#app p { /* main text */
+    color: #1a8591;
+}
+
+p.path span { /* sudo */
+    color: #b3534b;
+}
+
+p.path span + span { /* directory */
+    color: #476238;
+}
+
+.icone {
+    color: #81b6bc;
+}
+
+input {
+    color: #81b6bc;
+}
+
+.error {
+    color: #ff1276;
+}
+
+.container {
+    border: 1px solid #000000;
+}
+
+a {
+    color: #ff4d12;
+}


### PR DESCRIPTION
Adds 5 buttons in the menu section that the user can click to switch between different themes for the terminal. Theme palettes were sourced from several other common terminal applications like SecureCRT and PuTTY. Modifying any of them should that be desired is very easily done through each one's individual .css file. 

Any time the page is loaded it defaults to the main theme.  Currently the buttons are set to disappear when viewed on mobile as the h1 element has some issues below 404px and it would be far too crowded to have everything there. Eventually a dropdown style menu for them could be made fairly easily. The same goes for integrating each theme as a command, though in general most real-life terminals have some sort of gui for appearance options anyway :)

Fixes #16 